### PR TITLE
Namescape the groups claim

### DIFF
--- a/docs/01-auth0.md
+++ b/docs/01-auth0.md
@@ -35,8 +35,8 @@ Paste in this code to the rule and call it "Kubernetes-Group-Claims" or somethin
 
 ```javascript
 function (user, context, callback) {
-  //console.log(user.authorization.groups);
-  context.idToken.groups = user.authorization.groups;
+  const namespace = 'http://trondhindenes.k8s.example.com/';
+  context.idToken[namespace + 'groups'] = user.authorization.groups;
 
   callback(null, user, context);
 }

--- a/docs/02-kubernetes.md
+++ b/docs/02-kubernetes.md
@@ -7,7 +7,7 @@ minikube start \
       --extra-config=apiserver.Authorization.Mode=RBAC \
       --extra-config=apiserver.Authentication.OIDC.IssuerURL=https://myauth0domain.auth.com/ \
       --extra-config=apiserver.Authentication.OIDC.UsernameClaim=email \
-      --extra-config=apiserver.Authentication.OIDC.GroupsClaim=groups \
+      --extra-config=apiserver.Authentication.OIDC.GroupsClaim=http://trondhindenes.k8s.example.com/groups \
       --extra-config=apiserver.Authentication.OIDC.ClientID="wakkawakka"
 ``` 
 
@@ -15,7 +15,7 @@ The flags you need to pass are:
 `authorization-mode`: Set this to `RBAC`.
 `oidc-issuer-url`: This should be set to the value of the `Domain` in your Auth0 client settings. You MUST add a trailing slash. TRAILING. SLASH.
 `oidc-username-claim`: Should be set to `email`
-`oidc-groups-claim`: Should be set to `groups`. This is why we create the special rule in step 1, so that we have a `groups` attribute in the jwt data that Kubernetes inspects.
+`oidc-groups-claim`: Should be set to `groups` with the configured namespace prefixed. This is why we create the special rule in step 1, so that we have a `groups` attribute in the jwt data that Kubernetes inspects.
 `oidc-client-id`: Should be set to the value of the `Client ID` from your Auth0 client settings.
 
 Make sure you have kubectl (https://kubernetes.io/docs/tasks/tools/install-kubectl/) available locally and on your path.


### PR DESCRIPTION
Auth0 seems to enforce the usage of namespaces for customs claims
nowadays, because of that the process to setup the groups claim needs to
be changed. See https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims#custom-claims
for more information.